### PR TITLE
Remove 'test' at beginning

### DIFF
--- a/delayed_assert/delayed_assert.py
+++ b/delayed_assert/delayed_assert.py
@@ -45,7 +45,7 @@ def expect(expr, msg=None):
     stack_list = inspect.stack()
     for stack in stack_list:
         func_name = getattr(stack, 'function', stack[3])
-        if func_name.startswith('test'):
+        if func_name.__contains__('test'):
             caller = func_name
             break
 


### PR DESCRIPTION
the function should contain the word test but not necessarily begins with it